### PR TITLE
Fix gprel store macros

### DIFF
--- a/gas/config/tc-mips.c
+++ b/gas/config/tc-mips.c
@@ -12492,6 +12492,11 @@ macro (struct mips_cl_insn *ip, char *str)
 		  macro_build (&offset_expr, s, fmt, op[0], BFD_RELOC_GPREL16,
 			       mips_gp_register);
 		  relax_switch ();
+		  if (used_at) 
+		    {
+		      used_at = 0;
+		      tempreg = ZERO;
+		    }
 		}
 	      macro_build_lui (&offset_expr, tempreg);
 	      macro_build (&offset_expr, s, fmt, op[0],


### PR DESCRIPTION
Fixes [an old issue](https://sourceware.org/bugzilla/show_bug.cgi?id=6975) were macro'd stores of a gp-reachable symbol would erroneously throw `Error: macro used $at after ".set noat"` if `.set noat` was set, even though the expanded macro would make no use of `$at`.

Example problematic line that this PR fixes: (taken from the linked bugzilla issue)
```mips
.text
.set    noat
sw      $v0, small_data

.comm small_data, 4
```

First time doing anything GNU related, the fix seems to work as expected but I'm open to comments.